### PR TITLE
Only links to history if more than one sample

### DIFF
--- a/web/body.html
+++ b/web/body.html
@@ -35,7 +35,7 @@
 
           $sample_str = $row['sample'];
 
-          if (! $history)
+          if (! $history && in_array($sample_str, $updated))
              $sample_str = '<a href="?sample=' . $sample_str . '&energy=' . $energy . '&browse=true&history=on">' . $sample_str . '</a>';
 
           if ($sample === '' or preg_match('/' . $sample . '/', $row['sample']))

--- a/web/index.php
+++ b/web/index.php
@@ -45,10 +45,21 @@ if ($conn->connect_error)
 
 if ($inbrowser) {
 
+  // If the history is not viewed, get the list of samples that have a history
+  $updated = array();
+  if (! $history) {
+    $check_history = $conn->query('SELECT DISTINCT(sample) FROM ' .
+                                  $table . '_history GROUP BY sample HAVING COUNT(*) > 1');
+
+    while($row = $check_history->fetch_assoc())
+      array_push($updated, $row['sample']);
+
+  }
+
   // Get all the entries in the database, and then perform regex matching.
   // Matching happens in the body.
 
-  $result = $conn->query('SELECT sample, cross_section, last_updated, source, comments FROM ' . 
+  $result = $conn->query('SELECT sample, cross_section, last_updated, source, comments FROM ' .
                          $table . ' ORDER BY sample ASC, last_updated DESC');
 
   include 'body.html';

--- a/web/index.php
+++ b/web/index.php
@@ -48,8 +48,8 @@ if ($inbrowser) {
   // If the history is not viewed, get the list of samples that have a history
   $updated = array();
   if (! $history) {
-    $check_history = $conn->query('SELECT DISTINCT(sample) FROM ' .
-                                  $table . '_history GROUP BY sample HAVING COUNT(*) > 1');
+    $check_history = $conn->query('SELECT sample FROM ' . $table .
+                                  '_history GROUP BY sample HAVING COUNT(*) > 1');
 
     while($row = $check_history->fetch_assoc())
       array_push($updated, $row['sample']);


### PR DESCRIPTION
The clutter of useless links didn't look good. This also gives an overview of samples that have more than one cross section submitted.