### PR TITLE
Revert cross sections script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ before_script:
   - sudo service mysql restart
   # Need to use virtualenv python for Travis-CI
   # But we usually want to use the system python to avoid conflicts with CMSSW
-  - sed -i 's@#! /usr/bin/python@#! /usr/bin/env python@g' bin/*.py
+  - sed -i 's@#! /usr/bin/python@#! /usr/bin/env python@g' */*.py
 script: test/run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,7 @@ before_script:
   # Update with cross section entries in my.cnf
   - sudo bash -c "cat test/my.cnf >> /etc/mysql/my.cnf"
   - sudo service mysql restart
+  # Need to use virtualenv python for Travis-CI
+  # But we usually want to use the system python to avoid conflicts with CMSSW
+  - sed -i 's@#! /usr/bin/python@#! /usr/bin/env python@g' bin/*.py
 script: test/run_tests.sh

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ If it's not installed, you can always add it with:
 If you are on the Tier-3, ``MySQLdb`` should already be installed on your machine.
 You can easily add an existing installation to your path by running the ``setup.sh`` inside the location.
 
+### Note on running inside CMSSW environment
+
+Note, all the python executables use the system Python, ``/usr/bin/python``, in the shebang.
+This way, you will be able to access the command line tools while using CMSSW.
+However, using the Python modules within your own script that is using the CMSSW may fail since CMSSW does not have ``MySQLdb`` installed.
+
 ## Reading Cross Sections
 
 The main motivation for this repository is to provide an exceptionally lazy tool to find cross sections.
@@ -129,6 +135,17 @@ There's also a command line interface that can be used the following way:
 
 More usage information (like how to access alternate energies) can be gathered by
 calling the script without any arguments or with ``-h`` or ``--help`` as the first argument.
+
+### Reverting Cross Sections
+
+Cross sections can also be "updated" by reverting to old cross sections.
+Use ``revert_xs.py`` and follow the instructions on the screen.
+Here are some examples on how to call it.
+
+    revert_xs.py WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8
+    ENERGY=8 revert_xs.py WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8
+    revert_xs.py WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8 ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1
+    revert_xs.py --like 'ST_%'
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MIT Cross Section DB
 
+[![Build Status](https://travis-ci.org/MiT-HEP/CrossSecDB.svg?branch=master)](https://travis-ci.org/MiT-HEP/CrossSecDB)
+
 This repository holds tools for centralized updating and fetching of cross sections at MIT.
 Analyses throughout CMS have a variety of formats for storing their Monte Carlos cross sections.
 This is an attempt to store these cross sections in a clean, machine-friendly, and documented way.

--- a/bin/get_xs.py
+++ b/bin/get_xs.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/python
 
 """
 Usage:

--- a/bin/put_xs.py
+++ b/bin/put_xs.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/python
 
 """
 Usage:

--- a/bin/revert_xs.py
+++ b/bin/revert_xs.py
@@ -1,0 +1,151 @@
+#! /usr/bin/python
+
+"""
+Usage:
+
+  revert_xs.py [--like] SAMPLE [SAMPLE ...]
+
+This tool creates a session that you can use to easily revert
+cross sections in the central database to old values.
+It also allows for invalidation of cross sections.
+
+Using the '--like' flag will allow you to place a simple SQL
+LIKE statement to get a list of samples.
+All you need to know is that SQL uses '%' as wildcards.
+If you do this, all arguments will be used to generate lists with LIKE.
+
+By default, the my.cnf configuration file is a centrally maintained one.
+To point to your own file, set the environment variable $XSECCONF to the location.
+
+Also by default, the samples are read off of the 13 TeV table.
+To change energies, set the environment variable $ENERGY to something different.
+
+Example:
+
+  XSECCONF=$HOME/my.cnf ENERGY=8 revert_xs.py --like 'DM%'
+
+Author:
+
+  Daniel Abercrombie <dabercro@mit.edu>
+"""
+
+import os
+import sys
+import curses
+import textwrap
+
+from CrossSecDB import reader
+from CrossSecDB import inserter
+
+
+ENERGY = int(os.environ.get('ENERGY', 13))
+
+
+def main(args):
+    """
+    Parameters:
+    -----------
+      args (list): A list of samples to run the revert tool over.
+                   This is not a "star-arg" because a list is a more natural
+                   container to be throwing around in the rest of the script.
+    """
+
+    if not args:
+        print 'No datasets matched your --like parameters.'
+        exit(1)
+
+    history_dump = reader.dump_history(args, energy=ENERGY)
+
+    if not history_dump:
+        print 'No history found for any of your arguments: %s' % args
+        exit(2)
+
+    # This will be a list of tuples of (sample, xs, comments, old_xs)
+    values_to_change = []
+
+    stdscr = curses.initscr()
+    max_y, max_x = stdscr.getmaxyx()
+    win = stdscr.subwin(max_y - 4, max_x - 8, 2, 4)
+    bottom = max_y - 5
+
+    for key in sorted(history_dump):
+        win.addstr('%s\n' % key, curses.A_STANDOUT)
+
+        options = {
+            'i': {
+                'cross_section': 0.0,
+                }
+            }
+
+        for index, entry in enumerate(history_dump[key]):
+            if not index:
+                win.addstr('\nCurrent entry\n', curses.A_BOLD)
+            win.addstr('%s:' % index, curses.A_BOLD)
+            win.addstr(' Cross Section: %s     Last Updated: %s\n' % \
+                           (entry['cross_section'], entry['last_updated']))
+            win.addstr('\n   Source: %s\n' % entry['source'])
+            win.addstr('\n   Comments: %s\n' % \
+                       ('\n' + ' '*13).join(textwrap.wrap(entry['comments'], max_x - 25)))
+
+            win.addstr('-' * (max_x - 8))
+
+            options[str(index)] = entry
+
+        win.addstr('\ni: Invalidate (set cross section to 0.0)\n\n', curses.A_BOLD)
+        win.addstr('\nq: Quit revert attempt\n', curses.A_BOLD)
+
+        win.addstr(bottom, 0, 'Select an option (default 0, the current entry): ',
+                   curses.A_BOLD)
+
+        chosen = win.getstr()
+
+        win.erase()
+        win.refresh()
+
+        if chosen == 'q':
+            values_to_change = []
+            break
+
+        elif chosen != '1' and chosen in options.keys():
+            to_update = options[chosen]
+            comments = 'Reverted to match entry from %s by revert_xs.py' %\
+                to_update['last_updated'] \
+                if to_update['cross_section'] else \
+                'Dataset entry probably not valid. Set to 0.0.'
+            values_to_change.append(key, to_update['cross_section'], comments,
+                                    options['0']['cross_section'])
+
+    if values_to_change:
+        win.addstr('Review submission\n\n', curses.A_STANDOUT)
+
+        for sample, xs, _, new_xs in values_to_change:
+            win.addstr('%s: %s --> %s\n' % (sample, xs, new_xs))
+
+        submission = win.addstr(bottom, 0, 'Submit these changes? (y/n, default n): ',
+                                curses.A_BOLD)
+
+        if submission != 'y':
+            values_to_change = []
+
+    curses.endwin()
+
+    for sample, xs, comments, _ in values_to_change:
+        reader.put_xsec(sample, xs, 'Reverted by revert_xs.py', comments, energy=ENERGY)
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) == 1 or sys.argv[1] in ['-h', '--help']:
+        print __doc__
+        exit(0)
+
+    try:
+        if sys.argv[1] == '--like':
+            main(reader.get_samples_like(sys.argv[2:], energy=ENERGY))
+
+        else:
+            main(sys.argv[1:])
+
+    except Exception as e:
+        print e
+        curses.endwin()

--- a/bin/revert_xs.py
+++ b/bin/revert_xs.py
@@ -91,7 +91,7 @@ def main(args):
 
             options[str(index)] = entry
 
-        win.addstr('\ni: Invalidate (set cross section to 0.0)\n\n', curses.A_BOLD)
+        win.addstr('\ni: Invalidate (set cross section to 0.0)\n', curses.A_BOLD)
         win.addstr('\nq: Quit revert attempt\n', curses.A_BOLD)
 
         win.addstr(bottom, 0, 'Select an option (default 0, the current entry): ',
@@ -106,23 +106,24 @@ def main(args):
             values_to_change = []
             break
 
-        elif chosen != '1' and chosen in options.keys():
+        elif chosen != '0' and chosen in options.keys():
             to_update = options[chosen]
             comments = 'Reverted to match entry from %s by revert_xs.py' %\
                 to_update['last_updated'] \
                 if to_update['cross_section'] else \
                 'Dataset entry probably not valid. Set to 0.0.'
-            values_to_change.append(key, to_update['cross_section'], comments,
-                                    options['0']['cross_section'])
+            values_to_change.append((key, to_update['cross_section'], comments,
+                                     options['0']['cross_section']))
 
     if values_to_change:
         win.addstr('Review submission\n\n', curses.A_STANDOUT)
 
-        for sample, xs, _, new_xs in values_to_change:
-            win.addstr('%s: %s --> %s\n' % (sample, xs, new_xs))
+        for sample, xs, _, old_xs in values_to_change:
+            win.addstr('%s: %s --> %s\n' % (sample, old_xs, xs))
 
-        submission = win.addstr(bottom, 0, 'Submit these changes? (y/n, default n): ',
-                                curses.A_BOLD)
+        win.addstr(bottom, 0, 'Submit these changes? (y/n, default n): ',
+                   curses.A_BOLD)
+        submission = win.getstr()
 
         if submission != 'y':
             values_to_change = []
@@ -130,7 +131,7 @@ def main(args):
     curses.endwin()
 
     for sample, xs, comments, _ in values_to_change:
-        reader.put_xsec(sample, xs, 'Reverted by revert_xs.py', comments, energy=ENERGY)
+        inserter.put_xsec(sample, xs, 'Reverted by revert_xs.py', comments, energy=ENERGY)
 
 
 if __name__ == '__main__':

--- a/bin/web_get_xs.sh
+++ b/bin/web_get_xs.sh
@@ -7,7 +7,7 @@ SAMPLE=$1
 if [ -z $SAMPLE ] || [ "$SAMPLE" = "-h" ] || [ "$SAMPLE" = "--help" ] 
 then
 
-    perldoc $0
+    perldoc -T "$0"
     exit 0
 
 fi
@@ -38,26 +38,23 @@ done
 
 =head1 Usage
 
-web_get_xs.sh SAMPLE [SAMPLE [SAMPLE ...]]
+    web_get_xs.sh SAMPLE [SAMPLE [SAMPLE ...]]
 
 Print the cross sections for a list of samples.
 The output is sent to STDOUT, and separated by newlines.
-
 By default, the samples are read off of the 13 TeV table.
-To change energies, set the environment variable $ENERGY to something different.
+To change energies, set the environment variable C<$ENERGY> to something different.
 
 =head1 Examples
 
-get_xs_web.sh sample_stored_at_MIT
-
-get_xs_web.sh sample1 sample2
-
-ENERGY=8 get_xs_web.sh low_energy_sample_stored_at_MIT
+    web_get_xs.sh sample_stored_at_MIT
+    web_get_xs.sh sample1 sample2
+    ENERGY=8 web_get_xs.sh low_energy_sample_stored_at_MIT
 
 =head1 Important Notes
 
 This should be used from remote locations, such as LXPLUS.
-If running on the T3, it will probably be faster to use get_xs.py.
+If running on the T3, it will probably be faster to use F<get_xs.py>.
 However, the nice part of this script is that is can be run from any
 place with curl installed.
 

--- a/python/CrossSecDB/reader.py
+++ b/python/CrossSecDB/reader.py
@@ -2,14 +2,112 @@
 Author: Daniel Abercrombie <dabercro@mit.edu>
 """
 
-import logging
-
 from . import XSecConnection
 
-logger = logging.getLogger(__name__)
+class InvalidDataset(Exception):
+    pass
 
 class NoMatchingDataset(Exception):
     pass
+
+def dump_history(samples, cnf=None, energy=13):
+    """
+    Get a list of historical information for each dataset.
+
+    Parameters:
+    -----------
+      samples (list or str) - A list of samples or a single sample to get cross sections for.
+
+      cnf (str) - Location of the MySQL connection configuration file.
+                  (default None, see XSecConnection.__init__)
+
+      energy (int) - Energy to determine the table to look up cross sections from.
+                     (default 13)
+
+    Returns:
+    --------
+      A dictionary of historical information for each dataset.
+      Each key of the dictionary is a sample name from the samples passed.
+      The values under these keys are lists of dictionaries containing the history.
+      These lists contain the following information (with the verbatim keys):
+
+        - cross_section
+        - last_updated
+        - source
+        - comments
+
+      The list is sorted with the most recent update first.
+    """
+
+    if not isinstance(samples, list):
+        return dump_history([samples], cnf, energy)
+
+    conn = XSecConnection(write=False, cnf=cnf)
+
+    output = {}
+
+    query = """
+            SELECT cross_section, last_updated, source, comments
+            FROM xs_{0}TeV_history WHERE sample=%s
+            ORDER BY last_updated DESC
+            """.format(energy)
+
+    for sample in samples:
+        conn.curs.execute(query, (sample,))
+
+        to_add = [
+            {
+                'cross_section': result[0],
+                'last_updated': result[1],
+                'source': result[2],
+                'comments': result[3]
+            } for result in conn.curs.fetchall()
+        ]
+
+        if to_add:
+            output[sample] = to_add
+
+    return output
+
+
+def get_samples_like(patterns, cnf=None, energy=13, history=True):
+    """
+    Get the list of samples that are like a given patter or list of patterns.
+    This searches the history table by default due to its use in revert_xs.py.
+
+    Parameters:
+    -----------
+      patterns (list or str) - A list of patterns or a single pattern to match.
+
+      cnf (str) - Location of the MySQL connection configuration file.
+                  (default None, see XSecConnection.__init__)
+
+      energy (int) - Energy to determine the table to look up cross sections from.
+                     (default 13)
+
+    Returns:
+    --------
+      A list of samples that matches the pattern.
+    """
+
+    if not isinstance(patterns, list):
+        return get_samples_like([patterns], cnf, energy)
+
+    conn = XSecConnection(write=False, cnf=cnf)
+
+    output = []
+
+    # Let's get which table we want to query
+
+    table_suffix = '_history' if history else ''
+    query = 'SELECT sample FROM xs_{0}TeV{1} WHERE sample LIKE %s'.format(energy, table_suffix)
+
+    for pattern in patterns:
+        conn.curs.execute(query, (pattern,))
+        output.extend([result[0] for result in conn.curs.fetchall()])
+
+    return output
+
 
 def get_xsec(samples, cnf=None, energy=13):
     """
@@ -41,13 +139,10 @@ def get_xsec(samples, cnf=None, energy=13):
     conn = XSecConnection(write=False, cnf=cnf)
 
     output = []
+    query = 'SELECT cross_section FROM xs_{0}TeV WHERE sample=%s'.format(energy)
 
     for sample in samples:
-        query = 'SELECT cross_section FROM xs_%sTeV WHERE sample=%s'
-        params = (energy, sample)
-
-        logger.debug('About to execute\n%s\nwith\n%s', query, params)
-        conn.curs.execute(query, params)
+        conn.curs.execute(query, (sample,))
 
         check = conn.curs.fetchone()
 
@@ -55,6 +150,10 @@ def get_xsec(samples, cnf=None, energy=13):
             raise NoMatchingDataset('No matching dataset found for sample %s at energy %s TeV' % (sample, energy))
 
         output.append(check[0])
+
+    # If there is a zero in the output, that means it is invalid
+    if False in output:
+        raise InvalidDataset('Dataset %s is invalid! (cross section = 0)', samples[output.index(False)])
 
     # Give people behavior they would expect
     if len(output) == 1:

--- a/scripts/genxsecanalyzer/README.md
+++ b/scripts/genxsecanalyzer/README.md
@@ -2,8 +2,6 @@
 
 This simple pair of scripts uses the GenXSecAnalyzer to generate commands
 that will place calculated cross sections into the central database.
-The script itself requires that you use CMSSW to calculate the cross sections.
-The commands must then be run in a separate shell because `MySQLdb` is not installed in CMSSW's Python.
 
 Up to date details about the script and how to run it can be obtained by running.
 

--- a/scripts/genxsecanalyzer/xsec.sh
+++ b/scripts/genxsecanalyzer/xsec.sh
@@ -80,19 +80,19 @@ fi
 =head1 Description
 
 Takes a dataset or list of datasets and outputs a number of put_xs.py commands that will update the central database with the GenXSecAnalyzer results.
-These put_xs.py commands may need to be run in a separate shell since the MySQLdb Python package is not installed in CMSSW,
+These put_xs.py commands may need to be run in a separate shell since the C<MySQLdb> Python package is not installed in CMSSW,
 but you need CMSSW to run the GenXSecAnalyzer.
 
 =head1 Usage
 
-./xsec <DATASET or LIST> [DATASET ...]
+    ./xsec <DATASET or LISTE> [DATASET ...]
 
 DATASET can either be in the standard CMS notation (/Process/Conditions/DataTier) or the MIT notation (Process+Conditions+DataTier).
 This script will translate any MIT notation to the CMS notation before further processing.
 Alternatively, you can give the name of a file as the first parameter that contains a list of datasets in either format.
 
-If the input is individual datasets, the output commands with either be placed in a file called xsec_output.txt.
-Otherwise, the output will be placed in the same location as the input file with '.out' appended to the end of the name.
+If the input is individual datasets, the output commands with either be placed in a file called F<xsec_output.txt>.
+Otherwise, the output will be placed in the same location as the input file with `F<.out>' appended to the end of the name.
 
 After the output is generated, open a new window and run:
 

--- a/scripts/genxsecanalyzer/xsec.sh
+++ b/scripts/genxsecanalyzer/xsec.sh
@@ -83,7 +83,7 @@ Takes a dataset or list of datasets and outputs a number of put_xs.py commands t
 
 =head1 Usage
 
-    ./xsec <DATASET or LISTE> [DATASET ...]
+    ./xsec <DATASET or LIST> [DATASET ...]
 
 DATASET can either be in the standard CMS notation (/Process/Conditions/DataTier) or the MIT notation (Process+Conditions+DataTier).
 This script will translate any MIT notation to the CMS notation before further processing.

--- a/scripts/genxsecanalyzer/xsec.sh
+++ b/scripts/genxsecanalyzer/xsec.sh
@@ -80,8 +80,6 @@ fi
 =head1 Description
 
 Takes a dataset or list of datasets and outputs a number of put_xs.py commands that will update the central database with the GenXSecAnalyzer results.
-These put_xs.py commands may need to be run in a separate shell since the C<MySQLdb> Python package is not installed in CMSSW,
-but you need CMSSW to run the GenXSecAnalyzer.
 
 =head1 Usage
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -20,12 +20,14 @@ do
 
     # Check the results
 
-    if [ $? -ne 0 ]
+    RESULT=$?
+
+    if [ $RESULT -ne 0 ]
     then
 
         COUNTFAIL=$((COUNTFAIL + 1))
         tput setaf 1 2> /dev/null
-        echo "FAILED: $TESTSCRIPT"
+        echo "FAILED: $TESTSCRIPT with exit code $RESULT"
 
     else
 

--- a/test/test_revert.sh
+++ b/test/test_revert.sh
@@ -1,0 +1,77 @@
+#! /bin/bash
+
+#
+# Author: Daniel Abercrombie <dabercro@mit.edu>
+#
+
+ERRORS=0
+
+# First put the TestDataset twice
+
+put_xs.py 'source: test' TestDataset 10.0
+sleep 2
+put_xs.py 'source: test' TestDataset 20.0
+
+test `get_xs.py TestDataset` = "20.0" || ERRORS=$((ERRORS + 1))
+
+# Now try to revert
+# We pick from the menu 1 to get to the old cross section
+# 0 is the current cross section
+
+printf "1\ny\n" | revert_xs.py TestDataset
+
+test `get_xs.py TestDataset` = "10.0" || ERRORS=$((ERRORS + 1))
+
+# Now we want to invalidate
+# Now that the revert is included, the invalidate option should be 'i'
+
+printf "i\ny\n" | revert_xs.py TestDataset
+
+# This should fail that there is no valid cross section
+
+get_xs.py TestDataset && ERRORS=$((ERRORS + 1))
+
+# Let's try a different energy
+
+ENERGY=8 put_xs.py 'source: test' TestDataset 8.0
+sleep 2
+ENERGY=8 put_xs.py 'source: test' TestDataset 18.0
+
+printf "1\ny\n" | ENERGY=8 revert_xs.py TestDataset
+
+test `ENERGY=8 get_xs.py TestDataset` = "8.0" || ERRORS=$((ERRORS + 1))
+
+# Finally, let's make sure that running over an invalid dataset allows us to recover
+# Option 0 is keep the same as invalid, and option 1 is most recent "20.0"
+
+printf "1\ny\n" | revert_xs.py TestDataset
+
+test `get_xs.py TestDataset` = "20.0" || ERRORS=$((ERRORS + 1))
+
+# Finally, we want a real non-existent database to cause an error
+
+echo "About to cause crash on purpose. Use Ctrl + C if this hangs."
+
+revert_xs.py TestDataset && ERRORS=$((ERRORS + 1))
+
+# Now let's test --like!
+
+put_xs.py 'source: test' Like1 20.0
+put_xs.py 'source: test' Like2 30.0
+sleep 2
+put_xs.py 'source: test' Like1 25.0
+put_xs.py 'source: test' Like2 35.0
+
+test `get_xs.py Like1` = "25.0" || ERRORS=$((ERRORS + 1))
+test `get_xs.py Like2` = "35.0" || ERRORS=$((ERRORS + 1))
+
+printf "2\n2\ny\n" | revert_xs.py --like 'Like%'
+
+test `get_xs.py Like1` = "20.0" || ERRORS=$((ERRORS + 1))
+test `get_xs.py Like2` = "20.0" || ERRORS=$((ERRORS + 1))
+
+echo "About to cause crash on purpose. Use Ctrl + C if this hangs."
+
+revert_xs.py --like 'NotThere%' && ERRORS=$((ERRORS + 1))
+
+exit $ERRORS

--- a/test/test_revert.sh
+++ b/test/test_revert.sh
@@ -14,22 +14,34 @@ put_xs.py 'source: test' TestDataset 20.0
 
 test `get_xs.py TestDataset` = "20.0" || ERRORS=$((ERRORS + 1))
 
+echo $ERRORS
+
 # Now try to revert
 # We pick from the menu 1 to get to the old cross section
 # 0 is the current cross section
 
+get_xs.py TestDataset
+
+sleep 2
 printf "1\ny\n" | revert_xs.py TestDataset
 
+get_xs.py TestDataset
+
 test `get_xs.py TestDataset` = "10.0" || ERRORS=$((ERRORS + 1))
+
+echo $ERRORS
 
 # Now we want to invalidate
 # Now that the revert is included, the invalidate option should be 'i'
 
+sleep 2
 printf "i\ny\n" | revert_xs.py TestDataset
 
 # This should fail that there is no valid cross section
 
 get_xs.py TestDataset && ERRORS=$((ERRORS + 1))
+
+echo $ERRORS
 
 # Let's try a different energy
 
@@ -37,41 +49,55 @@ ENERGY=8 put_xs.py 'source: test' TestDataset 8.0
 sleep 2
 ENERGY=8 put_xs.py 'source: test' TestDataset 18.0
 
+sleep 2
 printf "1\ny\n" | ENERGY=8 revert_xs.py TestDataset
 
 test `ENERGY=8 get_xs.py TestDataset` = "8.0" || ERRORS=$((ERRORS + 1))
 
+echo $ERRORS
+
 # Finally, let's make sure that running over an invalid dataset allows us to recover
-# Option 0 is keep the same as invalid, and option 1 is most recent "20.0"
+# Option 0 is most recent "30.0"
 
-printf "1\ny\n" | revert_xs.py TestDataset
+put_xs.py 'test new' TestDataset 30.0
+sleep 2
+printf "0\n" | revert_xs.py TestDataset
 
-test `get_xs.py TestDataset` = "20.0" || ERRORS=$((ERRORS + 1))
+test `get_xs.py TestDataset` = "30.0" || ERRORS=$((ERRORS + 1))
+
+echo $ERRORS
 
 # Finally, we want a real non-existent database to cause an error
 
 echo "About to cause crash on purpose. Use Ctrl + C if this hangs."
 
-revert_xs.py TestDataset && ERRORS=$((ERRORS + 1))
+revert_xs.py NotThereDataset && ERRORS=$((ERRORS + 1))
+
+echo $ERRORS
 
 # Now let's test --like!
 
-put_xs.py 'source: test' Like1 20.0
-put_xs.py 'source: test' Like2 30.0
+put_xs.py 'source: test' Like1 20.0 Like2 30.0
 sleep 2
-put_xs.py 'source: test' Like1 25.0
-put_xs.py 'source: test' Like2 35.0
+put_xs.py 'source: test' Like1 25.0 Like2 35.0
 
 test `get_xs.py Like1` = "25.0" || ERRORS=$((ERRORS + 1))
 test `get_xs.py Like2` = "35.0" || ERRORS=$((ERRORS + 1))
 
-printf "2\n2\ny\n" | revert_xs.py --like 'Like%'
+echo $ERRORS
+
+sleep 2
+printf "1\n1\ny\n" | revert_xs.py --like 'Like%'
 
 test `get_xs.py Like1` = "20.0" || ERRORS=$((ERRORS + 1))
-test `get_xs.py Like2` = "20.0" || ERRORS=$((ERRORS + 1))
+test `get_xs.py Like2` = "30.0" || ERRORS=$((ERRORS + 1))
+
+echo $ERRORS
 
 echo "About to cause crash on purpose. Use Ctrl + C if this hangs."
 
 revert_xs.py --like 'NotThere%' && ERRORS=$((ERRORS + 1))
+
+echo $ERRORS
 
 exit $ERRORS

--- a/web/install.sh
+++ b/web/install.sh
@@ -5,7 +5,7 @@ CHECKARG=$1
 if [ ! -z $CHECKARG ]
 then
 
-    perldoc "$0"
+    perldoc -T "$0"
     exit 0
 
 fi
@@ -34,13 +34,13 @@ done
 =head1 CrossSecDB webpage installer
 
 Simply installs all contents of this directory that are not this file
-into your $HOME/public_html/CrossSecDB location.
+into your F<$HOME/public_html/CrossSecDB> location.
 
 Calling the script with an argument will bring up this help menu.
 
 =head1 Author
 
-Daniel Abercrombie
+Daniel Abercrombie <dabercro@mit.edu>
 
 =cut
  


### PR DESCRIPTION
After a messy attempt at GenXSecAnalyzer, I created an interactive script for reverting cross sections to old values. It will definitely crash when the history is too long though because it won't know where to draw the information.

Also
 - Slight improvement to POD documentation of shell scripts
 - Changed to use the system Python in scripts so one doesn't have to worry about using CMSSW (which doesn't have MySQLdb installed) while on the Tier-3
 - Added fancy build shield on the README