### PR TITLE
Scrolling pad for long histories

### DIFF
--- a/bin/revert_xs.py
+++ b/bin/revert_xs.py
@@ -41,10 +41,13 @@ from CrossSecDB import inserter
 ENERGY = int(os.environ.get('ENERGY', 13))
 
 
-def main(args):
+def main(stdscr, args):
     """
     Parameters:
     -----------
+      stdscr (curses screen): The result of curses.initscr().
+                              This allows the function to be wrapped.
+
       args (list): A list of samples to run the revert tool over.
                    This is not a "star-arg" because a list is a more natural
                    container to be throwing around in the rest of the script.
@@ -66,7 +69,6 @@ def main(args):
 
     # Initialize window
 
-    stdscr = curses.initscr()
     max_y, max_x = stdscr.getmaxyx()
     win = stdscr.subwin(max_y - 4, max_x - 8, 2, 4)
     bottom = max_y - 5
@@ -142,8 +144,6 @@ def main(args):
         if submission != 'y':
             values_to_change = []
 
-    curses.endwin()
-
     for sample, xs, source, comments, _ in values_to_change:
         inserter.put_xsec(sample, xs, source, comments, energy=ENERGY)
 
@@ -156,13 +156,7 @@ if __name__ == '__main__':
 
     # This crashes when trying to write too much to the screen
     # TODO: Change the window to a pad? and give ways to scroll to prevent crashes on overflow.
-    try:
-        if sys.argv[1] == '--like':
-            main(reader.get_samples_like(sys.argv[2:], energy=ENERGY))
+    args = reader.get_samples_like(sys.argv[2:], energy=ENERGY) \
+        if sys.argv[1] == '--like' else sys.argv[1:]
 
-        else:
-            main(sys.argv[1:])
-
-    except Exception as e:
-        print e
-        curses.endwin()
+    curses.wrapper(main, args)

--- a/bin/revert_xs.py
+++ b/bin/revert_xs.py
@@ -58,7 +58,6 @@ def main(stdscr, history_dump):
     """
 
     # Initialize window
-
     curses.use_default_colors()
     max_y, max_x = stdscr.getmaxyx()
     master_pad = curses.newpad(max_y, max_x - 8)
@@ -69,15 +68,55 @@ def main(stdscr, history_dump):
     # User input is displayed here
     input_pad = curses.newpad(1, max_x - 8)
     bottom = max_y - 2
+    input_pad.keypad(True)
+
+    # Here is a function for processing input
+    def process_input(input_query, confirmation = False):
+        buff = ''
+        current_char = 0
+        
+        # This is the top relative to the pad
+        history_pad_top = 0
+
+        if confirmation:
+            # These are the top and bottom on the screen
+            hist_top, hist_bot = (4, bottom - 2)
+            valid_chars = [110, 121]
+        else:
+            hist_top, hist_bot = (6, bottom - 8)
+            valid_chars = range(48, 57) + [105, 113]
+
+        while current_char not in [curses.KEY_ENTER, 10, 13]:
+            if current_char in valid_chars:
+                buff += chr(current_char)
+            elif buff and current_char in [curses.KEY_BACKSPACE, 127]:
+                buff = buff[:-1]
+            elif current_char in [curses.KEY_UP, curses.KEY_DOWN]:
+                adjustment = 14 - bottom if current_char == curses.KEY_UP else \
+                    (bottom - 14)/2
+                history_pad_top = max(history_pad_top + adjustment, 0)
+
+                history_pad.refresh(history_pad_top, 0,
+                                    hist_top, 6,
+                                    hist_bot, max_x - 12)
+                
+            input_pad.erase()
+            input_pad.addstr(input_query, curses.A_BOLD)
+            input_pad.addstr(buff)
+            input_pad.refresh(0, 0, bottom, 4, bottom + 2, max_x - 8)
+
+            current_char = input_pad.getch()
+
+        return buff
 
     # This will be a list of tuples of
     # (sample, new_xs, new_source, new_comments, old_xs)
     output = []
 
     # Go through all the samples in alphabetical order
-
     for key in sorted(history_dump):
         master_pad.erase()
+        history_pad.erase()
         master_pad.addstr('%s\n\n' % key, curses.A_STANDOUT)
         master_pad.addstr('Options from history (use up and down keys to scroll)', curses.A_BOLD)
 
@@ -110,14 +149,10 @@ def main(stdscr, history_dump):
         master_pad.addstr(bottom - 5, 2, 'q: ', curses.A_BOLD)
         master_pad.addstr('Quit revert attempt')
 
-        input_pad.addstr('Select an option (default 0, the current entry): ',
-                         curses.A_BOLD)
-
         master_pad.refresh(0, 0, 2, 4, bottom, max_x - 8)
         history_pad.refresh(0, 0, 6, 6, bottom - 8, max_x - 12)
-        input_pad.refresh(0, 0, bottom, 4, bottom + 2, max_x - 8)
 
-        chosen = input_pad.getstr()
+        chosen = process_input('Select cross section (default 0, the current entry): ')
 
         # If quit return nothing to be changed
         if chosen == 'q':
@@ -138,14 +173,17 @@ def main(stdscr, history_dump):
                                      comments, options['0']['cross_section']))
 
     if output:
-        win.addstr('Review submission\n\n', curses.A_STANDOUT)
+        master_pad.erase()
+        history_pad.erase()
+        master_pad.addstr('Review submission\n\n', curses.A_STANDOUT)
 
         for sample, xs, _, _, old_xs in output:
-            win.addstr('%s: %s --> %s\n' % (sample, old_xs, xs))
+            history_pad.addstr('%s: %s --> %s\n' % (sample, old_xs, xs))
 
-        win.addstr(bottom, 0, 'Submit these changes? (y/n, default n): ',
-                   curses.A_BOLD)
-        submission = win.getstr()
+        master_pad.refresh(0, 0, 2, 4, bottom, max_x - 8)
+        history_pad.refresh(0, 0, 4, 6, bottom - 2, max_x - 12)
+
+        submission = process_input('Submit these changes? (y/n, default n): ', True)
 
         if submission == 'y':
             return output
@@ -159,8 +197,6 @@ if __name__ == '__main__':
         print __doc__
         exit(0)
 
-    # This crashes when trying to write too much to the screen
-    # TODO: Change the window to a pad? and give ways to scroll to prevent crashes on overflow.
     args = reader.get_samples_like(sys.argv[2:], energy=ENERGY) \
         if sys.argv[1] == '--like' else sys.argv[1:]
 
@@ -176,5 +212,6 @@ if __name__ == '__main__':
 
     values_to_change = curses.wrapper(main, history_dump)
 
-    for sample, xs, source, comments, _ in values_to_change:
+    for sample, xs, source, comments, old_xs in values_to_change:
+        print '%s: %s --> %s' % (sample, old_xs, xs)
         inserter.put_xsec(sample, xs, source, comments, energy=ENERGY)


### PR DESCRIPTION
Before, long histories would causes curses to crash. Now, histories can be up to 1000 lines long (that should last for a while), and arrow keys can be used to scroll through history values. Scrolling speed is roughly proportional to screen size.